### PR TITLE
Build qt6

### DIFF
--- a/bionic/Dockerfile
+++ b/bionic/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update \
               libnss3-dev \
               libopenjp2-7-dev \
               libssl-dev \
-              locate \
+              mlocate \
               imagemagick \
               ninja-build \
               python3-dev \

--- a/bionic/Dockerfile
+++ b/bionic/Dockerfile
@@ -43,6 +43,29 @@ RUN apt-get update \
               qt515x11extras \
               wget \
               zlib1g-dev \
+              libfontconfig1-dev \
+              libfreetype6-dev \
+              libx11-dev \
+              libx11-xcb-dev \
+              libcext-dev \
+              libxfixes-dev \
+              libxi-dev \
+              libxrender-dev \
+              libxcb1-dev \
+              libxcb-glx0-dev \
+              libxcb-keysyms1-dev \
+              libxcb-image0-dev \
+              libxcb-shm0-dev \
+              libxcb-icccm4-dev \
+              libxcb-sync0-dev \
+              libxcb-xfixes0-dev \
+              libxcb-shape0-dev \
+              libxcb-randr0-dev \
+              libxcb-render-util0-dev \
+              libxcb-randr0-dev \
+              libxcb-xinerama0-dev \
+              libxkbcommon-dev \
+              libxkbcommon-x11-dev \
   && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - > /usr/share/keyrings/kitware-archive-keyring.gpg \
   && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic main' > /etc/apt/sources.list.d/kitware.list \
   && apt-get update \

--- a/bionic/Dockerfile
+++ b/bionic/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update \
               git \
               libboost-all-dev \
               libcairo2-dev \
+              libclang-dev \
               libdouble-conversion-dev \
               libffi-dev \
               libfuse2 \
@@ -30,7 +31,7 @@ RUN apt-get update \
               libnss3-dev \
               libopenjp2-7-dev \
               libssl-dev \
-              mlocate \
+              libtiff-dev \
               imagemagick \
               ninja-build \
               python3-dev \
@@ -67,5 +68,7 @@ RUN /install-qt6.sh
 
 COPY scripts/install-poppler.sh /
 RUN /install-poppler.sh
+
+RUN ldconfig
 
 RUN rm -rf /install-*.sh

--- a/bionic/Dockerfile
+++ b/bionic/Dockerfile
@@ -62,6 +62,9 @@ RUN /install-lib2geom.sh
 COPY scripts/install-fmt.sh /
 RUN /install-fmt.sh
 
+COPY scripts/install-qt6.sh /
+RUN /install-qt6.sh
+
 COPY scripts/install-poppler.sh /
 RUN /install-poppler.sh
 

--- a/focal/Dockerfile
+++ b/focal/Dockerfile
@@ -3,38 +3,43 @@ FROM ubuntu:focal
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \
-      build-essential \
-      clang \
-      clazy \
-      cmake \
-      g++ \
-      git \
-      libboost-all-dev \
-      libcairo2-dev \
-      libclang-dev \
-      libdouble-conversion-dev \
-      libffi-dev \
-      libgl-dev \
-      libgsl-dev \
-      libjpeg-dev \
-      libkf5itemmodels-dev \
-      libnss3-dev \
-      libopenjp2-7-dev \
-      libqt5svg5-dev \
-      libssl-dev \
-      libtiff-dev \
-      imagemagick \
-      mlocate \
-      ninja-build \
-      python3-dev \
-      python3-numpy \
-      qt5-default \
-      qtbase5-dev \
-      qtchooser \
-      qttools5-dev-tools \
-      qttools5-dev \
-      zlib1g-dev \
-    && rm -rf /var/lib/apt/lists/*
+              build-essential \
+              clang \
+              clazy \
+              g++ \
+              gcc \
+              gpg \
+              git \
+              libboost-all-dev \
+              libcairo2-dev \
+              libclang-dev \
+              libdouble-conversion-dev \
+              libffi-dev \
+              libgl-dev \
+              libgsl-dev \
+              libjpeg-dev \
+              libkf5itemmodels-dev \
+              libnss3-dev \
+              libopenjp2-7-dev \
+              libqt5svg5-dev \
+              libssl-dev \
+              libtiff-dev \
+              imagemagick \
+              ninja-build \
+              python3-dev \
+              python3-numpy \
+              qt5-default \
+              qtbase5-dev \
+              qtchooser \
+              qttools5-dev-tools \
+              qttools5-dev \
+              wget \
+              zlib1g-dev \
+  && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - > /usr/share/keyrings/kitware-archive-keyring.gpg \
+  && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic main' > /etc/apt/sources.list.d/kitware.list \
+  && apt-get update \
+  && apt-get install -y cmake \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY scripts/install-lib2geom.sh /
 RUN /install-lib2geom.sh

--- a/focal/Dockerfile
+++ b/focal/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y \
               libboost-all-dev \
               libcairo2-dev \
               libclang-dev \
+              libclang-9-dev \
               libdouble-conversion-dev \
               libffi-dev \
               libgl-dev \
@@ -23,6 +24,7 @@ RUN apt-get update && apt-get install -y \
               libopenjp2-7-dev \
               libqt5svg5-dev \
               libssl-dev \
+              libstdc++-10-dev \
               libtiff-dev \
               imagemagick \
               ninja-build \

--- a/focal/Dockerfile
+++ b/focal/Dockerfile
@@ -41,6 +41,9 @@ RUN apt-get update && apt-get install -y \
   && apt-get install -y cmake \
   && rm -rf /var/lib/apt/lists/*
 
+COPY scripts/install-cmake-extra-modules.sh /
+RUN /install-cmake-extra-modules.sh
+
 COPY scripts/install-lib2geom.sh /
 RUN /install-lib2geom.sh
 

--- a/focal/Dockerfile
+++ b/focal/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y \
       libssl-dev \
       libtiff-dev \
       imagemagick \
+      mlocate \
       ninja-build \
       python3-dev \
       python3-numpy \
@@ -46,5 +47,7 @@ RUN /install-qt6.sh
 
 COPY scripts/install-poppler.sh /
 RUN /install-poppler.sh
+
+RUN ldconfig
 
 RUN rm -rf /install-*.sh

--- a/focal/Dockerfile
+++ b/focal/Dockerfile
@@ -16,10 +16,13 @@ RUN apt-get update && apt-get install -y \
       libffi-dev \
       libgl-dev \
       libgsl-dev \
+      libjpeg-dev \
       libkf5itemmodels-dev \
-      libpoppler-qt5-dev \
+      libnss3-dev \
+      libopenjp2-7-dev \
       libqt5svg5-dev \
       libssl-dev \
+      libtiff-dev \
       imagemagick \
       ninja-build \
       python3-dev \
@@ -40,5 +43,8 @@ RUN /install-fmt.sh
 
 COPY scripts/install-qt6.sh /
 RUN /install-qt6.sh
+
+COPY scripts/install-poppler.sh /
+RUN /install-poppler.sh
 
 RUN rm -rf /install-*.sh

--- a/focal/Dockerfile
+++ b/focal/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
       git \
       libboost-all-dev \
       libcairo2-dev \
+      libclang-dev \
       libdouble-conversion-dev \
       libffi-dev \
       libgl-dev \
@@ -36,3 +37,8 @@ RUN /install-lib2geom.sh
 
 COPY scripts/install-fmt.sh /
 RUN /install-fmt.sh
+
+COPY scripts/install-qt6.sh /
+RUN /install-qt6.sh
+
+RUN rm -rf /install-*.sh

--- a/scripts/install-qt6.sh
+++ b/scripts/install-qt6.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+set -e
+
+git clone git://code.qt.io/qt/qt5.git
+cd qt5
+git checkout v6.0.4
+./init-repository --module-subset=qtbase,qtsvg,qttools,qttranslations,qtimageformats,qtshadertools,qtdeclarative,qtactiveqt
+cd ..
+mkdir build-qt6
+cd build-qt6
+../qt5/configure
+cd ..
+cmake --build build-qt6
+cmake --install build-qt6
+rm -rf qt5 build-qt6

--- a/scripts/install-qt6.sh
+++ b/scripts/install-qt6.sh
@@ -5,7 +5,7 @@ set -e
 git clone git://code.qt.io/qt/qt5.git
 cd qt5
 git checkout v6.0.4
-./init-repository --module-subset=qtbase,qtsvg,qttools,qttranslations,qtimageformats,qtshadertools,qtdeclarative,qtactiveqt
+./init-repository --module-subset=qtbase,qtsvg,qttools,qttranslations,qtimageformats,qtshadertools,qtdeclarative,qtactiveqt,qtx11extras
 cd ..
 mkdir build-qt6
 cd build-qt6


### PR DESCRIPTION
Since Ubuntu Bionic is required to build AppImage but it does not provide Qt 6 packages (there are no PPAs), there is no other way than building Qt from source.